### PR TITLE
Add `MetricBuilder` Static Types

### DIFF
--- a/src/Metric.php
+++ b/src/Metric.php
@@ -37,6 +37,8 @@ class Metric extends Model
 
     /**
      * Create a new Eloquent query builder for the model.
+     *
+     * @return MetricBuilder<static>
      */
     public function newEloquentBuilder($query): MetricBuilder
     {

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -12,7 +12,7 @@ class Metric extends Model
     /**
      * The attributes that aren't mass assignable.
      *
-     * @var array
+     * @var array<string>
      */
     protected $guarded = [];
 

--- a/src/MetricBuilder.php
+++ b/src/MetricBuilder.php
@@ -5,20 +5,29 @@ namespace DirectoryTree\Metrics;
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * @template TMetric of Metric
+ *
+ * @extends Builder<TMetric>
+ */
 class MetricBuilder extends Builder
 {
     /**
      * Get metrics for today.
+     *
+     * @return $this
      */
-    public function today(): self
+    public function today(): static
     {
         return $this->onDate(today());
     }
 
     /**
      * Get metrics for yesterday.
+     *
+     * @return $this
      */
-    public function yesterday(): self
+    public function yesterday(): static
     {
         return $this->onDate(
             today()->subDay()
@@ -27,24 +36,30 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for this hour.
+     *
+     * @return $this
      */
-    public function thisHour(): self
+    public function thisHour(): static
     {
         return $this->onDateTime(now());
     }
 
     /**
      * Get metrics for last hour.
+     *
+     * @return $this
      */
-    public function lastHour(): self
+    public function lastHour(): static
     {
         return $this->onDateTime(now()->subHour());
     }
 
     /**
      * Get metrics for this week.
+     *
+     * @return $this
      */
-    public function thisWeek(): self
+    public function thisWeek(): static
     {
         return $this->betweenDates(
             today()->startOfWeek(),
@@ -54,8 +69,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last week.
+     *
+     * @return $this
      */
-    public function lastWeek(): self
+    public function lastWeek(): static
     {
         return $this->betweenDates(
             today()->subWeek()->startOfWeek(),
@@ -65,8 +82,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for this month.
+     *
+     * @return $this
      */
-    public function thisMonth(): self
+    public function thisMonth(): static
     {
         return $this->betweenDates(
             today()->startOfMonth(),
@@ -76,8 +95,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last month.
+     *
+     * @return $this
      */
-    public function lastMonth(): self
+    public function lastMonth(): static
     {
         return $this->betweenDates(
             today()->subMonth()->startOfMonth(),
@@ -87,8 +108,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last month without overflow.
+     *
+     * @return $this
      */
-    public function lastMonthNoOverflow(): self
+    public function lastMonthNoOverflow(): static
     {
         return $this->betweenDates(
             today()->subMonthNoOverflow()->startOfMonth(),
@@ -98,8 +121,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for this quarter.
+     *
+     * @return $this
      */
-    public function thisQuarter(): self
+    public function thisQuarter(): static
     {
         return $this->betweenDates(
             today()->startOfQuarter(),
@@ -109,8 +134,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last quarter.
+     *
+     * @return $this
      */
-    public function lastQuarter(): self
+    public function lastQuarter(): static
     {
         return $this->betweenDates(
             today()->subQuarter()->startOfQuarter(),
@@ -120,8 +147,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last quarter without overflow.
+     *
+     * @return $this
      */
-    public function lastQuarterNoOverflow(): self
+    public function lastQuarterNoOverflow(): static
     {
         return $this->betweenDates(
             today()->subQuarterNoOverflow()->startOfQuarter(),
@@ -131,8 +160,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for this year.
+     *
+     * @return $this
      */
-    public function thisYear(): self
+    public function thisYear(): static
     {
         return $this->betweenDates(
             today()->startOfYear(),
@@ -142,8 +173,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last year.
+     *
+     * @return $this
      */
-    public function lastYear(): self
+    public function lastYear(): static
     {
         return $this->betweenDates(
             today()->subYear()->startOfYear(),
@@ -153,8 +186,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics for last year without overflow.
+     *
+     * @return $this
      */
-    public function lastYearNoOverflow(): self
+    public function lastYearNoOverflow(): static
     {
         return $this->betweenDates(
             today()->subYearNoOverflow()->startOfYear(),
@@ -164,8 +199,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics between two dates.
+     *
+     * @return $this
      */
-    public function betweenDates(CarbonInterface $start, CarbonInterface $end): self
+    public function betweenDates(CarbonInterface $start, CarbonInterface $end): static
     {
         return $this->whereRaw(
             '(year, month, day) >= (?, ?, ?) AND (year, month, day) <= (?, ?, ?)',
@@ -178,8 +215,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics between two datetimes (including hours).
+     *
+     * @return $this
      */
-    public function betweenDateTimes(CarbonInterface $start, CarbonInterface $end): self
+    public function betweenDateTimes(CarbonInterface $start, CarbonInterface $end): static
     {
         return $this->whereRaw(
             '(year, month, day, hour) >= (?, ?, ?, ?) AND (year, month, day, hour) <= (?, ?, ?, ?)',
@@ -192,8 +231,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics on a specific date.
+     *
+     * @return $this
      */
-    public function onDate(CarbonInterface $date): self
+    public function onDate(CarbonInterface $date): static
     {
         return $this->where(function (Builder $query) use ($date) {
             $query
@@ -205,8 +246,10 @@ class MetricBuilder extends Builder
 
     /**
      * Get metrics on a specific date and hour.
+     *
+     * @return $this
      */
-    public function onDateTime(CarbonInterface $hour): self
+    public function onDateTime(CarbonInterface $hour): static
     {
         return $this->onDate($hour)->where('hour', $hour->hour);
     }

--- a/src/MetricFactory.php
+++ b/src/MetricFactory.php
@@ -4,6 +4,9 @@ namespace DirectoryTree\Metrics;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 
+/**
+ * @extends Factory<Metric>
+ */
 class MetricFactory extends Factory
 {
     /**


### PR DESCRIPTION
To make this a little easier to work with with static analysis, looked to improve the typing of `MetricBuilder`. This adds the `@extend` annotation so that the underlying Builder instance will indicate it is outputting the `Metric`.

Using the `@template` tag allows for `MetricBuilder` to be overridden in the consuming app to reference an overridden `Metric`.

While looking at times handled a few other small items.

Thanks for the package! Let me know if you'd like me to handle anything differently.